### PR TITLE
Don't remove cookbook paths, just add to list berkshelf cookbook path

### DIFF
--- a/lib/berkshelf/vagrant/action/configure_chef.rb
+++ b/lib/berkshelf/vagrant/action/configure_chef.rb
@@ -10,9 +10,11 @@ module Berkshelf
         end
 
         def call(env)
-          if chef_solo?(env) && env[:berkshelf].shelf
-            provisioners(:chef_solo, env).each do |provisioner|
-              provisioner.config.cookbooks_path << [:host, env[:berkshelf].shelf]
+          if false == env[:global_config].berkshelf.disabled
+            if chef_solo?(env) && env[:berkshelf].shelf
+              provisioners(:chef_solo, env).each do |provisioner|
+                provisioner.config.cookbooks_path << [:host, env[:berkshelf].shelf]
+              end
             end
           end
 

--- a/lib/berkshelf/vagrant/action/install.rb
+++ b/lib/berkshelf/vagrant/action/install.rb
@@ -10,10 +10,12 @@ module Berkshelf
         end
 
         def call(env)
-          env[:berkshelf].berksfile = Berkshelf::Berksfile.from_file(env[:global_config].berkshelf.berksfile_path)
+          if false == env[:global_config].berkshelf.disabled
+            env[:berkshelf].berksfile = Berkshelf::Berksfile.from_file(env[:global_config].berkshelf.berksfile_path)
 
-          if chef_solo?(env)
-            install(env)
+            if chef_solo?(env)
+              install(env)
+            end
           end
 
           @app.call(env)

--- a/lib/berkshelf/vagrant/action/load_shelf.rb
+++ b/lib/berkshelf/vagrant/action/load_shelf.rb
@@ -10,13 +10,15 @@ module Berkshelf
         end
 
         def call(env)
-          shelf = load_shelf
+          if false == env[:global_config].berkshelf.disabled
+            shelf = load_shelf
 
-          if shelf.nil?
-            shelf = cache_shelf(Berkshelf::Vagrant.mkshelf)
+            if shelf.nil?
+              shelf = cache_shelf(Berkshelf::Vagrant.mkshelf)
+            end
+
+            env[:berkshelf].shelf = shelf
           end
-
-          env[:berkshelf].shelf = shelf
 
           @app.call(env)
         end

--- a/lib/berkshelf/vagrant/action/upload.rb
+++ b/lib/berkshelf/vagrant/action/upload.rb
@@ -10,8 +10,10 @@ module Berkshelf
         end
 
         def call(env)
-          if chef_client?(env)
-            upload(env)
+          if false == env[:global_config].berkshelf.disabled
+            if chef_client?(env)
+              upload(env)
+            end
           end
 
           @app.call(env)

--- a/spec/unit/berkshelf/vagrant/config_spec.rb
+++ b/spec/unit/berkshelf/vagrant/config_spec.rb
@@ -9,6 +9,11 @@ describe Berkshelf::Vagrant::Config do
     subject.berksfile_path.should eql(File.join(Dir.pwd, "Berksfile"))
   end
 
+  it "set the value of disabled to a false" do
+    subject.disabled.should be_a(FalseClass)
+    subject.disabled.should eql(false)
+  end
+
   it "sets the value of only to an empty array" do
     subject.only.should be_a(Array)
     subject.only.should be_empty


### PR DESCRIPTION
Don't remove cookbook paths, just add to list berkshelf cookbook path.

The problem what I can have also own directories with cookbooks:

``` ruby
config.vm.provision :chef_solo do |chef|
    chef.cookbooks_path = ["site-cookbooks", "cookbooks"]
end
```

berkshelf should add own directory to this list (shouldn't remove my list).
