### PR TITLE
Trigger the plugin also on `vagrant reload`

### DIFF
--- a/lib/berkshelf/vagrant/plugin.rb
+++ b/lib/berkshelf/vagrant/plugin.rb
@@ -17,6 +17,7 @@ module Berkshelf
       DESC
 
       action_hook(:berkshelf_provision, :machine_action_up, &method(:provision))
+      action_hook(:berkshelf_provision, :machine_action_reload, &method(:provision))
       action_hook(:berkshelf_provision, :machine_action_provision, &method(:provision))
 
       action_hook(:berkshelf_cleanup, :machine_action_destroy) do |hook|


### PR DESCRIPTION
Fix `vagrant reload` not installing the berkshelf nor setting up cookbooks_path etc.
