### PR TITLE
add guard for loading plugin outside of a viable version of Vagrant

### DIFF
--- a/lib/berkshelf/vagrant.rb
+++ b/lib/berkshelf/vagrant.rb
@@ -4,10 +4,6 @@ rescue LoadError
   raise "The Vagrant Berkshelf plugin must be run within Vagrant."
 end
 
-if Vagrant::VERSION < "1.1.0"
-  raise "The Vagrant Berkshelf plugin is only compatible with Vagrant 1.1+"
-end
-
 require 'berkshelf'
 require 'berkshelf/vagrant/version'
 require 'berkshelf/vagrant/errors'


### PR DESCRIPTION
@ivey 
