### PR TITLE
Deal with vagrant-aws custom provision actions

### DIFF
--- a/lib/berkshelf/vagrant/plugin.rb
+++ b/lib/berkshelf/vagrant/plugin.rb
@@ -7,8 +7,12 @@ module Berkshelf
         def provision(hook)
           hook.after(::Vagrant::Action::Builtin::Provision, Berkshelf::Vagrant::Action.upload)
           hook.after(::Vagrant::Action::Builtin::Provision, Berkshelf::Vagrant::Action.install)
-          hook.after(::VagrantPlugins::AWS::Action::TimedProvision, Berkshelf::Vagrant::Action.upload)
-          hook.after(::VagrantPlugins::AWS::Action::TimedProvision, Berkshelf::Vagrant::Action.install)
+
+          if ::VagrantPlugins.const_defined?(:AWS)
+            hook.after(::VagrantPlugins::AWS::Action::TimedProvision, Berkshelf::Vagrant::Action.upload)
+            hook.after(::VagrantPlugins::AWS::Action::TimedProvision, Berkshelf::Vagrant::Action.install)
+          end
+
           hook.before(::Vagrant::Action::Builtin::ConfigValidate, Berkshelf::Vagrant::Action.setup)
         end
       end


### PR DESCRIPTION
vagrant-aws uses VagrantPlugins::AWS::Action::TimedProvision, which means
our provision tasks don't run on 'vagrant up'.

This is a dumb way to fix it, but it will work until we have something better.

Fixes #8 
