### PR TITLE
not overwrite cookbooks_path, just append

### DIFF
--- a/lib/berkshelf/vagrant/action/configure_chef.rb
+++ b/lib/berkshelf/vagrant/action/configure_chef.rb
@@ -16,7 +16,7 @@ module Berkshelf
 
           if chef_solo?(env) && shelf = env[:berkshelf].shelf
             provisioners(:chef_solo, env).each do |provisioner|
-              provisioner.config.cookbooks_path = provisioner.config.send(:prepare_folders_config, shelf)
+              provisioner.config.cookbooks_path += provisioner.config.send(:prepare_folders_config, shelf)
             end
           end
 


### PR DESCRIPTION
I want to use both berkshelf cookbooks_path and self configured cookbooks_path.

I tested it with this test branch. https://github.com/riywo/vagrant-berkshelf/tree/keep_cookbooks_path_test

Currently, this change is hard to write rspec because it is an integrated test and needs some helpers for Vagrantfile, like [this](https://github.com/mitchellh/vagrant/blob/master/test/unit/support/isolated_environment.rb). 

If you think the test is required, I can try to create some helpers for this tiny modification.

Thanks!
