### PR TITLE
Use Berkshelf 2.0.0

### DIFF
--- a/vagrant-berkshelf.gemspec
+++ b/vagrant-berkshelf.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 1.9.1'
 
-  spec.add_dependency 'berkshelf', '~> 1.4.0'
+  spec.add_dependency 'berkshelf', '~> 2.0.0'
   # activesupport 3.2.13 contains an incompatible hard lock on i18n (= 0.6.1)
   spec.add_dependency 'activesupport', '>= 3.2.0', '< 3.2.13'
 


### PR DESCRIPTION
Fixes #54. Tests pass, plugin works with Vagrant 1.2.2 (and without the update wouldn't run because of http://stackoverflow.com/questions/16878741/including-apache-for-vagrant-will-not-up).
