### PR TITLE
The CONTRIBUTING.md file refers to a nonstandard `bundle-vagrant` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Clone the project
 and run:
 
     $ cd vagrant-berkshelf
-    $ bundle-vagrant install
+    $ bundle install
 
 Bundler will install all gems and their dependencies required for testing and developing.
 


### PR DESCRIPTION
It's either artifact of maintainer's work environment, or a custom
script that the file should describe how to install. Plain `bundle`
worked for me.
