### PR TITLE
use env[:machine] for vagrant enable/disable

### DIFF
--- a/lib/berkshelf/vagrant/env_helpers.rb
+++ b/lib/berkshelf/vagrant/env_helpers.rb
@@ -48,7 +48,7 @@ module Berkshelf
       #
       # @return [Boolean]
       def berkshelf_enabled?(env)
-        env[:global_config].berkshelf.enabled
+        env[:machine].config.berkshelf.enabled
       end
 
       # Determine if --no-provision was specified


### PR DESCRIPTION
this allows you to specify on a per box basis if berkshelf is enabled or disabled

This should address issues #72 and allow you to disable berkshelf per vm definition.

With this change you can now do 

``` ruby
Vagrant.configure("2") do |config|
  config.vm.define "foo" do |cfg|
    cfg.berkshelf.enabled = false
    ...
  end
end
```

/cc @claco
