### PR TITLE
Do not overwrite vagrant's cookbooks_path

### DIFF
--- a/lib/berkshelf/vagrant/action/configure_chef.rb
+++ b/lib/berkshelf/vagrant/action/configure_chef.rb
@@ -16,7 +16,7 @@ module Berkshelf
 
           if chef_solo?(env) && shelf = env[:berkshelf].shelf
             provisioners(:chef_solo, env).each do |provisioner|
-              provisioner.config.cookbooks_path = provisioner.config.send(:prepare_folders_config, shelf)
+              provisioner.config.cookbooks_path.unshift(provisioner.config.send(:prepare_folders_config, shelf))
             end
           end
 

--- a/spec/unit/berkshelf/vagrant/action/configure_chef_spec.rb
+++ b/spec/unit/berkshelf/vagrant/action/configure_chef_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Berkshelf::Vagrant::Action::ConfigureChef do
+  let(:app) { proc {} }
+  let(:chef_solo_provisioner) { double("Vagrant::Provisioners::Chef::ChefSolo", :name => :chef_solo) }
+  let(:env) do
+    {
+      :machine => double("Machine"),
+      :berkshelf => double("Berkshelf", :shelf => double("shelf"))
+    }
+  end
+
+  it "appends shelf path to vagrant's cookbooks_path" do
+    env[:machine].stub_chain(:config, :vm, :provisioners).and_return([chef_solo_provisioner])
+    env[:machine].stub_chain(:config, :berkshelf, :enabled).and_return(true)
+
+    cookbooks_path = ["/path/to/my-cookbooks"]
+    chef_solo_provisioner.stub_chain(:config, :cookbooks_path).and_return(cookbooks_path)
+    chef_solo_provisioner.stub_chain(:config, :prepare_folders_config).and_return("/path/to/berkshelf-cookbooks")
+
+    described_class.new(app, env).call(env)
+
+    expect(cookbooks_path).to include("/path/to/my-cookbooks", "/path/to/berkshelf-cookbooks")
+  end
+end
+


### PR DESCRIPTION
In my chef repo, I'd like to have a single Berksfile and single virtual machine to test my cookbooks on. Nevertheless, vagrant-berkshelf overwrites default cookbooks_path for some reason. It wasn't like that until 685cabe2f8ab39335e756ffa9de4d069e73c3746.
The test I wrote is the most horrible test I made ever, so it might be better to not include it :)
