### PR TITLE
Compatibility with vagrant-aws v0.4.0

### DIFF
--- a/lib/berkshelf/vagrant/plugin.rb
+++ b/lib/berkshelf/vagrant/plugin.rb
@@ -6,9 +6,10 @@ module Berkshelf
           hook.after(::Vagrant::Action::Builtin::Provision, Berkshelf::Vagrant::Action.upload)
           hook.after(::Vagrant::Action::Builtin::Provision, Berkshelf::Vagrant::Action.install)
 
-          if ::VagrantPlugins.const_defined?(:AWS)
-            hook.after(::VagrantPlugins::AWS::Action::TimedProvision, Berkshelf::Vagrant::Action.upload)
-            hook.after(::VagrantPlugins::AWS::Action::TimedProvision, Berkshelf::Vagrant::Action.install)
+          # vagrant-aws < 0.4.0 uses a non-standard provision action
+          if defined?(VagrantPlugins::AWS::Action::TimedProvision)
+            hook.after(VagrantPlugins::AWS::Action::TimedProvision, Berkshelf::Vagrant::Action.upload)
+            hook.after(VagrantPlugins::AWS::Action::TimedProvision, Berkshelf::Vagrant::Action.install)
           end
 
           hook.before(::Vagrant::Action::Builtin::ConfigValidate, Berkshelf::Vagrant::Action.setup)


### PR DESCRIPTION
Next vagrant-aws release will remove its custom `TimedProvision` class and use only the standard `Builtin::Provision` instead: mitchellh/vagrant-aws@dd17f23.

To support both old and new versions of the plugin, check if the `TimedProvision` class is defined before using it.

This PR is based on v1.3.3 tag (in the hope of a point release :))  but it merges cleanly to the current master, too.
