### PR TITLE
Replace Solve with RubyGems in Vagrant version checking

### DIFF
--- a/lib/berkshelf/vagrant/action/install.rb
+++ b/lib/berkshelf/vagrant/action/install.rb
@@ -54,16 +54,20 @@ module Berkshelf
           end
 
           def check_vagrant_version(env)
-            unless Solve::Constraint.new(">= 1.1").satisfies?(::Vagrant::VERSION)
+            unless vagrant_version_satisfies?(">= 1.1")
               raise Berkshelf::VagrantWrapperError.new(RuntimeError.new("vagrant-berkshelf requires Vagrant 1.1 or later."))
             end
 
-            unless Solve::Constraint.new(::Berkshelf::Vagrant::TESTED_CONSTRAINT).satisfies?(::Vagrant::VERSION)
+            unless vagrant_version_satisfies?(::Berkshelf::Vagrant::TESTED_CONSTRAINT)
               env[:berkshelf].ui.warn "This version of the Berkshelf plugin has not been fully tested on this version of Vagrant."
               env[:berkshelf].ui.warn "You should check for a newer version of vagrant-berkshelf."
               env[:berkshelf].ui.warn "If you encounter any errors with this version, please report them at https://github.com/RiotGames/vagrant-berkshelf/issues"
               env[:berkshelf].ui.warn "You can also join the discussion in #berkshelf on Freenode."
             end
+          end
+
+          def vagrant_version_satisfies?(requirement)
+            Gem::Requirement.new(requirement).satisfied_by? Gem::Version.new(::Vagrant::VERSION)
           end
       end
     end


### PR DESCRIPTION
`Solve::Constraint` doesn't support pre-release version numbers (#97, RiotGames/solve#29), so replace it with `Gem` classes while waiting for a fix.
