### PR TITLE
Add rbx to run tests against in TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - rbx
+matrix:
+  allow_failures:
+    - ruby: rbx
 notifications:
   irc:
     channels:


### PR DESCRIPTION
These directives will still allow failures of these interpreters but at
least we're testing them.
