### PR TITLE
Don't lock down activesupport

### DIFF
--- a/vagrant-berkshelf.gemspec
+++ b/vagrant-berkshelf.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.1'
 
   spec.add_dependency 'berkshelf', '~> 2.0.7'
-  # activesupport 3.2.13 contains an incompatible hard lock on i18n (= 0.6.1)
-  spec.add_dependency 'activesupport', '>= 3.2.0', '< 3.2.13'
 
   # Explicit locks to ensure we activate the proper gem versions for Vagrant
   spec.add_dependency 'i18n', '~> 0.6.0'


### PR DESCRIPTION
v3.2.14 already loosened the i18n requirement and all new versions are compatible with Vagrant's requirement (`~> 0.6.0`).

Sorry to spam with minor changes. Feel free to reject. Master branch (and berkshelf) has already dropped the whole dependency.

No idea if there are any relevant fixes in the new versions. My main motivation is to get the [Gemnasium status](https://gemnasium.com/gems/vagrant-berkshelf) :traffic_light: from red to green. =)
