### PR TITLE
Use recommended download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Vagrant plugin to add Berkshelf integration to the Chef provisioners
 
 ## Installation
 
-Install Vagrant 1.5.x from the [Vagrant downloads page](http://downloads.vagrantup.com/)
+Install Vagrant 1.5.x from the [Vagrant downloads page](http://www.vagrantup.com/downloads.html)
 
 Install the Vagrant Berkshelf plugin
 


### PR DESCRIPTION
Vagrantup.com recommends a new fancy page for downloads with a distinct [archive](http://www.vagrantup.com/downloads-archive.html) for older versions.

The legacy page only lists releases up to 1.3.*.
