### PR TITLE
update vagrant minor version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The current release candidate of Vagrant Berkshelf requires you to have Gecode i
 
 ### Vagrant & Plugin Installation
 
-Install Vagrant 1.5.x from the [Vagrant downloads page](http://www.vagrantup.com/downloads.html)
+Install Vagrant '>= 1.5.2' from the [Vagrant downloads page](http://www.vagrantup.com/downloads.html)
 
 Install the Vagrant Berkshelf plugin
 


### PR DESCRIPTION
I was using vagrant 1.5.1, and I kept getting errors that was fixed in the workaround posted a few weeks ago chulkilee@c5d6e55

When upgrading to the new steps defined in this README, I kept getting

Bundler could not find compatible versions for gem "celluloid":
  In Gemfile:
    vagrant-berkshelf (>= 0) ruby depends on
      celluloid (~> 0.16.0.pre) ruby

```
vagrant (= 1.5.1) ruby depends on
  celluloid (0.15.2)
```

When upgrading to vagrant 1.5.2 it works fine. Please accept this pull request to prevent people like me from wasting time :)
