### PR TITLE
Add installation of Berkshelf in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ The current release candidate of Vagrant Berkshelf requires you to have Gecode i
     $ make
     $ (sudo) make install
 
+### Berkshelf Installation
+
+Install Berkshelf
+
+    $ gem install berkshelf -v '3.0.0.rc1'
+
 ### Vagrant & Plugin Installation
 
 Install Vagrant '>= 1.5.2' from the [Vagrant downloads page](http://www.vagrantup.com/downloads.html)


### PR DESCRIPTION
Reading the installation instructions, I miss an important part for the total newbies like me: the installation of Berkshelf (otherwise one has to dig and look for those instructions, which are usually very confusing, since versions 2 and 3 mix up in different pages).

I still couldn't get vagrant-berkshelf working as expected, so perhaps gem install berkshelf -v '3.0.0.rc1' isn't actually what should be done, but if this is wrong then this is a way to humbly ask you how Berkshelf should be installed (thank you in advance!)
