### PR TITLE
Fix installation instructions to avoid downgrading of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install Vagrant '>= 1.5.2' from the [Vagrant downloads page](http://www.vagrantu
 
 Install the Vagrant Berkshelf plugin
 
-    $ vagrant plugin install vagrant-berkshelf --plugin-version 2.0.1
+    $ vagrant plugin install vagrant-berkshelf --plugin-version '>= 2.0.1'
 
 ## Usage
 


### PR DESCRIPTION
Lock down the lowest version to avoid accidental downgrading when installing other plugins. 

Relates to mitchellh/vagrant#3537 and schisamo/vagrant-omnibus#76.
