### PR TITLE
Fixed install command to work on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install Vagrant '>= 1.5.2' from the [Vagrant downloads page](http://www.vagrantu
 
 Install the Vagrant Berkshelf plugin
 
-    $ vagrant plugin install vagrant-berkshelf --plugin-version '>= 2.0.1'
+    $ vagrant plugin install vagrant-berkshelf --plugin-version ">= 2.0.1"
 
 ## Usage
 


### PR DESCRIPTION
On Windows the install command with single quotes fails with the following error.

``` text
C:\>vagrant plugin install vagrant-berkshelf --plugin-version '>=2.0.1'
C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.3/lib/vagrant/plugin/v2/command.rb:59:in `parse_options': invalid argument: --plugin-version  (OptionParser::InvalidArgument)
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.3/plugins/commands/plugin/command/install.rb:26:in `execute'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.3/plugins/commands/plugin/command/root.rb:56:in `execute'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.3/lib/vagrant/cli.rb:42:in `execute'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.3/lib/vagrant/environment.rb:252:in `cli'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.3/bin/vagrant:166:in `<main>'
```
