### PR TITLE
Change double quotes to single quotes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install Vagrant '>= 1.5.2' from the [Vagrant downloads page](http://www.vagrantu
 
 Install the Vagrant Berkshelf plugin
 
-    $ vagrant plugin install vagrant-berkshelf --plugin-version ">= 2.0.1"
+    $ vagrant plugin install vagrant-berkshelf --plugin-version '>= 2.0.1'
 
 ## Usage
 


### PR DESCRIPTION
The install command in the README throws out this error.

```
Bundler, the underlying system Vagrant uses to install plugins,
reported an error. The error is shown below. These errors are usually
caused by misconfigured plugin installations or transient network
issues. The error from Bundler is:

Net::HTTPNotFound: No gems found matching "vagrant-vmware-workstation" "2.3.6" nil
```

I discovered that using single quotes instead of double quotes resolved the issue for me.
