### PR TITLE
Fix EnvHelpers.provisioners helper for vagrant 1.7

### DIFF
--- a/lib/berkshelf/vagrant/env_helpers.rb
+++ b/lib/berkshelf/vagrant/env_helpers.rb
@@ -59,8 +59,15 @@ module Berkshelf
       #   environment to inspect
       #
       # @return [Array]
-      def provisioners(name, env)
-        env[:machine].config.vm.provisioners.select { |prov| prov.name == name }
+      def provisioners(type, env)
+        env[:machine].config.vm.provisioners.select do |prov|
+          # Vagrant 1.7 changes prov.name to prov.type
+          if prov.respond_to? :type
+            prov.type == type
+          else
+            prov.name == type
+          end
+        end
       end
 
       # Determine if the given vagrant environment contains a chef_solo provisioner


### PR DESCRIPTION
I set out to add support for the new vagrant 1.7 chef_zero provisioner and noticed vagrant 1.7 changed the meaning of config.vm.provisioners.name (basically renamed to config.vm.provisioners.type).

This is a fix to the EnvHelper module to account for both pre-1.7 and post-1.7 behavior.
