### PR TITLE
Add support for new vagrant 1.7 chef_zero provisioner

### DIFF
--- a/lib/berkshelf/vagrant/action/configure_chef.rb
+++ b/lib/berkshelf/vagrant/action/configure_chef.rb
@@ -19,6 +19,12 @@ module Berkshelf
             end
           end
 
+          if chef_zero?(env) && shelf = env[:berkshelf].shelf
+            provisioners(:chef_zero, env).each do |provisioner|
+              provisioner.config.cookbooks_path = provisioner.config.send(:prepare_folders_config, shelf)
+            end
+          end
+
           @app.call(env)
         end
       end

--- a/lib/berkshelf/vagrant/action/install.rb
+++ b/lib/berkshelf/vagrant/action/install.rb
@@ -23,7 +23,7 @@ module Berkshelf
             return @app.call(env)
           end
 
-          if chef_solo?(env)
+          if chef_solo?(env) || chef_zero?(env)
             vendor(env)
           end
 

--- a/lib/berkshelf/vagrant/env_helpers.rb
+++ b/lib/berkshelf/vagrant/env_helpers.rb
@@ -72,6 +72,15 @@ module Berkshelf
         provisioners(:chef_solo, env).any?
       end
 
+      # Determine if the given vagrant environment contains a chef_zero provisioner
+      #
+      # @param [Vagrant::Environment] env
+      #
+      # @return [Boolean]
+      def chef_zero?(env)
+        provisioners(:chef_zero, env).any?
+      end
+
       # Determine if the given vagrant environment contains a chef_client provisioner
       #
       # @param [Vagrant::Environment] env


### PR DESCRIPTION
This is a simple changeset to add support for the new vagrant 1.7 chef_zero provisioner.  Note: it requires the fix from https://github.com/berkshelf/vagrant-berkshelf/pull/230 to work.
