### PR TITLE
Fix File.read()'s missing argument

### DIFF
--- a/lib/vagrant-berkshelf/action/upload.rb
+++ b/lib/vagrant-berkshelf/action/upload.rb
@@ -70,7 +70,7 @@ module VagrantPlugins
             path = File.expand_path(ENV['BERKSHELF_CONFIG'] || '~/.berkshelf/config.json')
 
             if File.exist?(path)
-              JSON.parse(File.read(), symbolize_names: true)
+              JSON.parse(File.read(path), symbolize_names: true)
             else
               {}
             end


### PR DESCRIPTION
Fix the `read': wrong number of arguments (0 for 1..4) (ArgumentError)
when the config.json exists for berkshelf.
