### PR TITLE
Fix issue with using berksfile_path config when uploading

### DIFF
--- a/lib/vagrant-berkshelf/action/upload.rb
+++ b/lib/vagrant-berkshelf/action/upload.rb
@@ -86,7 +86,7 @@ module VagrantPlugins
                 env[:machine].ui.info "Uploading cookbooks to #{provisioner.config.chef_server_url}"
                 berks("upload",
                   config:    config,
-                  berksfile: provisioner.config.berkshelf.berksfile_path,
+                  berksfile: env[:machine].config.berkshelf.berksfile_path,
                   force:     true,
                   freeze:    false,
                 )


### PR DESCRIPTION
Hi,

I'm just using vagrant-berkshlef 4.0.1 and I encounter below error message when uploading cookbook.

```
==> db0.stack: Uploading cookbooks to http://172.16.41.222:4000
 INFO subprocess: Starting process: ["/opt/chefdk/bin/berks", "upload"]
 INFO warden: Calling IN action: #<Vagrant::Action::Builtin::Provision:0x000000040d0bc0>
 INFO provision: Ignoring sentinel check, forcing provision
 INFO provision: Checking provisioner sentinel file...
 INFO provision: Sentinel found! Not provisioning.
 INFO warden: Calling IN action: #<VagrantPlugins::ProxyConf::Action::OnlyOnce:0x00000004103020>
 INFO warden: Calling IN action: #<VagrantPlugins::Omnibus::Action::InstallChef:0x00000004102ff8>
 INFO warden: Calling IN action: #<VagrantPlugins::ProxyConf::Action::OnlyOnce:0x00000004138bf8>
 INFO warden: Calling IN action: #<VagrantPlugins::Cachier::Action::InstallBuckets:0x00000004138bd0>
 INFO warden: Calling IN action: #<Proc:0x0000000262c990@/opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:94 (lambda)>
 INFO warden: Calling IN action: #<Proc:0x00000003d54640@/opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:94 (lambda)>
 INFO warden: Calling OUT action: #<Proc:0x00000003d54640@/opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:94 (lambda)>
 INFO warden: Calling OUT action: #<Proc:0x0000000262c990@/opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:94 (lambda)>
 INFO warden: Calling OUT action: #<VagrantPlugins::Cachier::Action::InstallBuckets:0x00000004138bd0>
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 11 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Warden:0x00000003d308d0>
 INFO warden: Calling IN action: #<Proc:0x00000003f6e980@/opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:94 (lambda)>
 INFO warden: Calling IN action: #<Vagrant::Action::Builtin::Call:0x00000003d30470>
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 11 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x000000040277a0>
 INFO warden: Calling IN action: #<VagrantPlugins::ProxyConf::Action::IsEnabled:0x00000004080940>
 INFO warden: Calling OUT action: #<VagrantPlugins::ProxyConf::Action::IsEnabled:0x00000004080940>
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 11 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Warden:0x000000040d6048>
 INFO warden: Calling IN action: #<Proc:0x0000000415dd68@/opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:94 (lambda)>
 INFO warden: Calling IN action: #<VagrantPlugins::ProxyConf::Action::ConfigureAptProxy:0x000000040d5f08>
 INFO machine: Calling action: read_ssh_info on provider Libvirt (19cec100-263c-48b3-b999-5c9ed7055485)
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 9 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x00000005962da0>
 INFO warden: Calling IN action: #<VagrantPlugins::Triggers::Action::Trigger:0x00000003619fd8>
 INFO warden: Calling IN action: #<VagrantPlugins::Triggers::Action::Trigger:0x00000003b7dc40>
 INFO warden: Calling IN action: #<VagrantPlugins::Triggers::Action::Trigger:0x00000003cee048>
 INFO warden: Calling IN action: #<Vagrant::Action::Builtin::EnvSet:0x00000003d91590>
 INFO warden: Calling IN action: #<VagrantPlugins::ChefZero::Action::Reconfig:0x00000003d914a0>
 INFO warden: Calling IN action: #<Vagrant::Action::Builtin::ConfigValidate:0x00000003d9b5e0>
ERROR warden: Error occurred: There are errors in the configuration of this machine. Please fix
the following errors and try again:

chef client provisioner:
* The following settings shouldn't exist: berkshelf
* The following settings shouldn't exist: berkshelf

```

Anyway, I just patch below code and this error is gone way.
I don't know well about vagrant and berkshlef wolkflow. So, if this is not a bug then just ignore please. :)
