### PR TITLE
don't check for berks executable and correct version if the plugin is disabled

### DIFF
--- a/lib/vagrant-berkshelf/action/check.rb
+++ b/lib/vagrant-berkshelf/action/check.rb
@@ -7,6 +7,11 @@ module VagrantPlugins
         BERKS_REQUIREMENT = "~> 3.2"
 
         def call(env)
+          if !berkshelf_enabled?(env)
+            @logger.info "Berkshelf disabled, skipping"
+            return @app.call(env)
+          end
+
           check_berks_bin!(env)
           berkshelf_version_check!(env)
 


### PR DESCRIPTION
Don't try to check for the berks executable and correct version if the plugin is disabled.

It's related to [this comment](https://github.com/test-kitchen/test-kitchen/issues/575#issuecomment-68399469) where we discussed to disable vagrant-berkshelf in test-kitchen/kitchen-vagrant (because test-kitchen itself already resolves the dependencies via berks).
