### PR TITLE
Setup actions after config validation

### DIFF
--- a/lib/vagrant-berkshelf/plugin.rb
+++ b/lib/vagrant-berkshelf/plugin.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
 
       [:machine_action_up, :machine_action_reload, :machine_action_provision].each do |action|
         action_hook(:berkshelf_provision, action) do |hook|
-          hook.before(Vagrant::Action::Builtin::ConfigValidate, Action::Base.setup)
+          hook.after(Vagrant::Action::Builtin::ConfigValidate, Action::Base.setup)
           hook.before(Vagrant::Action::Builtin::Provision, Action::Base.provision)
         end
       end


### PR DESCRIPTION
`berkshelf_enabled?(env)` works incorrect before config validation.
For example, share action synced empty berkshelf directory if I have no `Berksfile` in project directory and I don't set
`berksfile.enable` to `true`, because `@enable` attribute has MAYBE
value before validation.
