### PR TITLE
 Preserve cookbooks_path set in Vagrantfile

### DIFF
--- a/lib/vagrant-berkshelf/action/share.rb
+++ b/lib/vagrant-berkshelf/action/share.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             value = chef.config.send(:prepare_folders_config, env[:berkshelf].shelf)
 
             @logger.debug "Setting cookbooks_path = #{value.inspect}"
-            chef.config.cookbooks_path += value
+            chef.config.cookbooks_path = value + Array(chef.config.cookbooks_path)
           end
 
           @app.call(env)

--- a/lib/vagrant-berkshelf/action/share.rb
+++ b/lib/vagrant-berkshelf/action/share.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             value = chef.config.send(:prepare_folders_config, env[:berkshelf].shelf)
 
             @logger.debug "Setting cookbooks_path = #{value.inspect}"
-            chef.config.cookbooks_path = value
+            chef.config.cookbooks_path += value
           end
 
           @app.call(env)


### PR DESCRIPTION
 In addition to the cookbooks specified in Berksfile, site-cookbooks
 might be necessary in some cases. So cookbooks_path set in Vagrantfile
 should be preserved rather than overwritten.