### PR TITLE
add to, rather than overwriting, the chef cookbooks_path config

### DIFF
--- a/lib/vagrant-berkshelf/action/share.rb
+++ b/lib/vagrant-berkshelf/action/share.rb
@@ -21,12 +21,32 @@ module VagrantPlugins
           list.each do |chef|
             value = chef.config.send(:prepare_folders_config, env[:berkshelf].shelf)
 
-            @logger.debug "Setting cookbooks_path = #{value.inspect}"
-            chef.config.cookbooks_path = value
+            @logger.debug "adding #{value.inspect} to cookbook_paths"
+            chef.config.cookbooks_path = merge_paths(chef.config.cookbooks_path, value)
           end
 
           @app.call(env)
         end
+
+        protected
+
+        def merge_paths(a, b)
+          normalized_path(a) + normalized_path(b)
+        end
+
+        def normalized_path(path_config_ish)
+          if path_config_ish == Vagrant::Plugin::V2::Config::UNSET_VALUE
+            []
+
+          elsif path_config_ish.respond_to?(:first) and
+                path_config_ish.first.is_a?(Symbol)
+            [path_config_ish]
+
+          else
+            Array(path_config_ish)
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
Overwriting the cookbooks path results in breaking chef_zero provisioners since they need to specify a cookbook directory also.