### PR TITLE
Include no-freeze and force options in berks command

### DIFF
--- a/lib/vagrant-berkshelf/helpers.rb
+++ b/lib/vagrant-berkshelf/helpers.rb
@@ -45,6 +45,14 @@ module VagrantPlugins
           args += options[:only]
         end
 
+        if options[:freeze] == false
+          args << "--no-freeze"
+        end
+
+        if options[:force]
+          args << "--force"
+        end
+
         if !options.fetch(:args, []).empty?
           args += options[:args]
         end


### PR DESCRIPTION
When berks upload is called, the upload action sets options to not freeze cookbooks and force upload (even if frozen). However, the helper class, that builds the berks command, does not process these options.

Upload action code:
```ruby
module VagrantPlugins
  module Berkshelf
    module Action
      class Upload < Base

       ....

          # Upload the resolved Berkshelf cookbooks to the target Chef Server
          # specified in the Vagrantfile.
          #
          # @param [Vagrant::Environment] env
          def upload(env)
            provisioners(:chef_client, env).each do |provisioner|
              with_provision_berkshelf_config(provisioner) do |config|
                env[:machine].ui.info "Uploading cookbooks to #{provisioner.config.chef_server_url}"
                berks("upload",
                  config:         config,
                  berksfile_path: env[:machine].config.berkshelf.berksfile_path,
                  force:          true,
                  freeze:         false,
                )
              end
            end
          end
      end
    end
  end
end
```

Helper code:
```ruby
module VagrantPlugins
  module Berkshelf
    # A module of common helper functions that can be mixed into Berkshelf::Vagrant actions
    module Helpers
      include Vagrant::Util

      # Execute a berkshelf command with the given arguments and flags.
      #
      # @overload berks(command, args)
      #   @param [String] berks CLI command to run
      #   @param [Object] any number of arguments to pass to CLI
      # @overload berks(command, args, options)
      #   @param [String] berks CLI command to run
      #   @param [Object] any number of arguments to pass to CLI
      #   @param [Hash] options to convert to flags for the CLI
      #
      # @return [String]
      #   output of the command
      #
      # @raise [InvalidBerkshelfVersionError]
      #   version of Berks installed does not satisfy the application's constraint
      # @raise [BerksNotFoundError]
      #   berks command is not found in the user's path
      def berks(command, *args)
        options = args.last.is_a?(Hash) ? args.pop : {}
        args = args.dup

        if options[:berksfile_path]
          args << "--berksfile"
          args << options[:berksfile_path]
        end

        if !options.fetch(:except, []).empty?
          args << "--except"
          args += options[:except]
        end

        if !options.fetch(:only, []).empty?
          args << "--only"
          args += options[:only]
        end

        if !options.fetch(:args, []).empty?
          args += options[:args]
        end

        final_command = [berks_bin, command, *args]

        Bundler.with_clean_env do
          r = Subprocess.execute(*final_command)
          if r.exit_code != 0
            raise BerksCommandFailed.new(final_command.join(' '), r.stdout, r.stderr)
          end
          r
        end
      end
```

In the helper, there is no code to transform the `freeze = false` into `--no-freeze` and the `force = true` into `--force`.

To verify the resulting command. clone the cookbook in https://github.com/miguelaferreira/vagrant_berkshelf_tests/tree/no-freeze-force-options
and run `vagrant up --debug`.
At some point there will be the message ` INFO subprocess: Starting process: ["/opt/chefdk/bin/berks", "upload"]` that shows the berks upload command without the desired options.

Since, by default berks upload will freeze cookbooks, it turns out that from the second time that you run vagrant onwards, any cookbook that has been already uploaded is skipped.
This is a problem when developing/testing cookbooks, because changes made to the cookbook will not be propagated tot he server, and therefore, also not to the hosts.