### PR TITLE
Fix ChefDK URL in post install message, too

### DIFF
--- a/vagrant-berkshelf.gemspec
+++ b/vagrant-berkshelf.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 The Vagrant Berkshelf plugin requires Berkshelf from the Chef Development Kit.
 You can download the latest version of the Chef Development Kit from:
 
-    https://downloads.getchef.com/chef-dk
+    https://downloads.chef.io/chef-dk/
 
 Installing Berkshelf via other methods is not officially supported.
 EOH


### PR DESCRIPTION
Just saw that it was fixed in the README in 5433386a890a7747762ae298c6b3e688e1cb54c1, but then noticed the old URL in the post install message after installing 4.0.4

This should fix it and I found no other occurrences of "getchef" in this repo