### PR TITLE
Fix: trim nfs mount

### DIFF
--- a/lib/vagrant-berkshelf/action/load.rb
+++ b/lib/vagrant-berkshelf/action/load.rb
@@ -40,7 +40,7 @@ module VagrantPlugins
             FileUtils.mkdir_p(shelves)
           end
 
-          Dir.mktmpdir(['berkshelf', "-#{env[:machine].name}"], shelves)
+          Dir.mktmpdir('bs', shelves)
         end
       end
     end


### PR DESCRIPTION
On FreeBSD nfs mounts (path + host) are limited to 88 characters.
Which means that excluding the IP, there's 73 characters left to
build a path that works.

I can't do much about a long username, but e.g. I can try to trim
the path berkshelf creates to share the shelf into the VM.

I shortened "berkshelf" to "bs", and I dropped the suffix. Unless
I don't understand Dir.mktmpdir(), I think this should be "unique"
enough to work.

I'd add a test if someone gives me an idea what to test for. :)
