### PR TITLE
Support berkshelf 5.0

### DIFF
--- a/lib/vagrant-berkshelf/action/check.rb
+++ b/lib/vagrant-berkshelf/action/check.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module Berkshelf
     module Action
       class Check < Base
-        BERKS_REQUIREMENT = "~> 4.0"
+        BERKS_REQUIREMENT = ">= 4.0"
 
         def call(env)
           if !berkshelf_enabled?(env)


### PR DESCRIPTION
There's no reason we can't support both 4.0 and 5.0.

Closes https://github.com/berkshelf/vagrant-berkshelf/pull/306 and
https://github.com/berkshelf/vagrant-berkshelf/issues/305