### PR TITLE
Remove ChefDK dependency in favor of berkshelf gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # vagrant-berkshelf Changelog
 
+## 6.0.0
+
+- Remove ChefDK dependency
+
 ## 5.1.2
 
 - Loosen the vagrant dependency to allow for Vagrant 2.X

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ See Seth Vargo's blog post for additional information on Test Kitchen vs. Vagran
 ## Installation
 
 1. Install the latest version of [Vagrant](https://www.vagrantup.com/downloads.html)
-2. Install the latest version of [ChefDK](https://downloads.chef.io/chef-dk/)
 3. Install the Vagrant Berkshelf plugin:
 
   ```sh

--- a/lib/vagrant-berkshelf/errors.rb
+++ b/lib/vagrant-berkshelf/errors.rb
@@ -2,22 +2,9 @@ require 'vagrant/errors'
 
 module VagrantPlugins
   module Berkshelf
-    INSTALL_CHEFDK_INSTRUCTIONS = <<-EOH.freeze
-Please download and install the latest version of the ChefDK from:
-
-    https://downloads.chef.io/chef-dk
-
-and follow the installation instructions. Do not forget to add the ChefDK to
-your PATH.
-EOH
-
     class BerkshelfNotFound < Vagrant::Errors::VagrantError
       def error_message
-        <<-EOH
-Vagrant Berkshelf could not find the 'berks' executable in your PATH.
-
-#{INSTALL_CHEFDK_INSTRUCTIONS}
-EOH
+        "Vagrant Berkshelf could not find the 'berks' executable in your PATH."
       end
     end
 
@@ -25,20 +12,6 @@ EOH
       def initialize(command, stdout, stderr)
         @command, @stdout, @stderr = command, stdout, stderr
         super
-      end
-
-      def chefdk?
-        @command.include?("chefdk")
-      end
-
-      def not_chefdk_message
-        <<-EOH
-It appears that you are not using the ChefDK. Please note that Vagrant Berkshelf
-works best when used with the ChefDK, and other installation methods are not
-officially supported.
-
-#{INSTALL_CHEFDK_INSTRUCTIONS}
-EOH
       end
 
       def error_message
@@ -53,7 +26,6 @@ The stdout and stderr are shown below:
     stderr: #{@stderr}
 EOH
 
-        base << "\n#{not_chefdk_message}" if !chefdk?
         base
       end
     end
@@ -70,8 +42,6 @@ EOH
         <<-EOH
 The Berkshelf version at #{@bin.inspect} is invalid.
 Vagrant Berkshelf requires #{@constraint}, but the current version is #{@version}.
-
-#{INSTALL_CHEFDK_INSTRUCTIONS}
 EOH
       end
     end

--- a/lib/vagrant-berkshelf/version.rb
+++ b/lib/vagrant-berkshelf/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Berkshelf
-    VERSION = "5.1.2"
+    VERSION = '6.0.0'
   end
 end

--- a/vagrant-berkshelf.gemspec
+++ b/vagrant-berkshelf.gemspec
@@ -27,14 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.post_install_message = <<-EOH
-The Vagrant Berkshelf plugin requires Berkshelf from the Chef Development Kit.
-You can download the latest version of the Chef Development Kit from:
-
-    https://downloads.chef.io/chefdk
-
-Installing Berkshelf via other methods is not officially supported.
-EOH
+  spec.add_runtime_dependency 'berkshelf'
 
   spec.add_development_dependency 'spork', '~> 0.9'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Motivation: not everyone who are trying to run Vagrant with Chef provisioning prefer to have the bulky installation of ChefDK, and berksfile gem simply works.

Judging by the amount of issues complaining about being unable to locate berksfile gem, this is often a problem:
https://github.com/berkshelf/vagrant-berkshelf/issues/318
https://github.com/berkshelf/vagrant-berkshelf/issues/315

I have doubts about this PR getting merged, as it's an opinionated change, and repo itself is [somewhat abandoned](https://github.com/berkshelf/vagrant-berkshelf/issues/321), so I am going to maintain a fork with new vagrant plugin, i.e. `vagrant-berkshelf-nochefdk` if this won't get accepted soon.